### PR TITLE
suggest to use `npm ci` in example && typo fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,9 +81,9 @@ jobs:
       uses: sma11black/hexo-action@v1.0.1
       with:
         deploy_key: ${{ secrets.DEPLOY_KEY }}
-        user_name: your github username  # (or delelte this input setting to use bot account)
-        user_email: your github useremail  # (or delelte this input setting to use bot account)
-        commit_msg: ${{ github.event.head_commit.message }}  # (or delelte this input setting to use hexo default settings)
+        user_name: your github username  # (or delete this input setting to use bot account)
+        user_email: your github useremail  # (or delete this input setting to use bot account)
+        commit_msg: ${{ github.event.head_commit.message }}  # (or delele this input setting to use hexo default settings)
     # Use the output from the `deploy` step(use for test action)
     - name: Get the output
       run: |

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ jobs:
           ${{ runner.os }}-node-
     - name: Install Dependencies
       if: steps.cache.outputs.cache-hit != 'true'
-      run: npm install
+      run: npm ci
     
     # Deploy hexo blog website.
     - name: Deploy


### PR DESCRIPTION
> In short, the main differences between using npm install and npm ci are:
>
>  *  The project must have an existing package-lock.json or npm-shrinkwrap.json.
>  *  If dependencies in the package lock do not match those in package.json, npm ci will exit with an error, instead of updating the package lock.
>     npm ci can only install entire projects at a time: individual dependencies cannot be added with this command.
>  *  If a node_modules is already present, it will be automatically removed before npm ci begins its install.
>  *  It will never write to package.json or any of the package-locks: installs are essentially frozen.
> 
> From: https://docs.npmjs.com/cli/ci

Use `npm ci` to ensure npm install packages according to `package-lock.json`. 