### PR TITLE
npm install hexo

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -15,6 +15,7 @@ git config --global user.email "$INPUT_USER_EMAIL"
 # install hexo env
 npm install hexo-cli -g
 npm install hexo-deployer-git --save
+npm install hexo --save
 
 # deployment
 if [ "$INPUT_COMMIT_MSG" = "none" ]


### PR DESCRIPTION
Hi, 
this action(tag v1.0.4) was working fine. 
but one day I got this error:

`Error: Cannot find module 'hexo'`

[more detail here](https://github.com/marsen/Marsen.Node.Hexo/actions/runs/3142194519/jobs/5105504717)

and I download this repository on my Macbook(M1)
build and run the image. same error !!

anyway, 
I added this `npm install hexo --save` for myself, 
and it's working again. 

I didn't get the root cause(why it was working and why not),
but hope this pr helply.
